### PR TITLE
Feature: Add --auth Functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         mongodb-version: ['4.0', '4.2', '4.4']
+        mongodb-db: ['ci']
+        mongodb-username: ['ci']
+        mongodb-password: ['ci']
 
     steps:
       - name: Checkout
@@ -19,3 +22,6 @@ jobs:
         uses: ./
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
+          mongodb-db: ${{ matrix.mongodb-db }}
+          mongodb-username: ${{ matrix.mongodb-username }}
+          mongodb-password: ${{ matrix.mongodb-password }}

--- a/.github/workflows/test-replica-set.yml
+++ b/.github/workflows/test-replica-set.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   single-node-replica-set-on-default-port:
-    name: MongoDB RS on default port v${{ matrix.mongodb-version }} — Node.js v${{ matrix.node-version }}
+    name: MongoDB v${{ matrix.mongodb-version }} RS on default port — Node.js v${{ matrix.node-version }}
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test-single-instance.yml
+++ b/.github/workflows/test-single-instance.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         node-version: [12, 14, 16]
         mongodb-version: ['4.0', '4.2', '4.4']
+        mongodb-db: ['ci']
+        mongodb-username: ['ci']
+        mongodb-password: ['ci']
 
     steps:
       - name: Checkout
@@ -20,6 +23,9 @@ jobs:
         uses: ./
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
+          mongodb-db: ${{ matrix.mongodb-db }}
+          mongodb-username: ${{ matrix.mongodb-username }}
+          mongodb-password: ${{ matrix.mongodb-password }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -33,6 +39,9 @@ jobs:
         run: npm test ./test/single-instance.js
         env:
           CI: true
+          MONGODB_DB: ${{ matrix.mongodb-db }}
+          MONGODB_USERNAME: ${{ matrix.mongodb-username }}
+          MONGODB_PASSWORD: ${{ matrix.mongodb-password }}
 
 
   single-instance-on-custom-port:
@@ -41,6 +50,9 @@ jobs:
       matrix:
         mongodb-port: [12345]
         mongodb-version: ['4.0', '4.2', '4.4']
+        mongodb-db: ['ci']
+        mongodb-username: ['ci']
+        mongodb-password: ['ci']
         node-version: [12, 14, 16]
 
     name: MongoDB on custom port v${{ matrix.mongodb-version }} — Node.js v${{ matrix.node-version }}
@@ -53,6 +65,9 @@ jobs:
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-port: ${{ matrix.mongodb-port }}
+          mongodb-db: ${{ matrix.mongodb-db }}
+          mongodb-username: ${{ matrix.mongodb-username }}
+          mongodb-password: ${{ matrix.mongodb-password }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -66,3 +81,6 @@ jobs:
         run: npm test ./test/custom-port.js
         env:
           CI: true
+          MONGODB_DB: ${{ matrix.mongodb-db }}
+          MONGODB_USERNAME: ${{ matrix.mongodb-username }}
+          MONGODB_PASSWORD: ${{ matrix.mongodb-password }}

--- a/README.md
+++ b/README.md
@@ -156,6 +156,51 @@ jobs:
 ```
 
 
+### With `--auth`
+Setting the `mongodb-username` and `mongodb-password` inputs. As per the [Dockerhub documentation](https://hub.docker.com/_/mongo), this automatically creates an admin user and enables `--auth` mode. _Caveat: Due to [this issue](https://github.com/docker-library/mongo/issues/211), you cannot enable user creation AND replica sets initially. Therefore, if you use this action to setup a replica set, please create your users through a separate script._
+
+The following example uses the username and password 'ci' and also sets an initial 'ci' database:
+
+```yaml
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x]
+        mongodb-version: ['4.0', '4.2', '4.4']
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.6.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+        mongodb-db: ci
+        mongodb-username: ci
+        mongodb-password: ci
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test
+      env:
+        CI: true
+```
+
+
 ## License
 MIT © [Supercharge](https://superchargejs.com)
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,21 @@ inputs:
     required: false
     default: 27017
 
+  mongodb-db:
+    description: 'MongoDB db to create (default: none)'
+    required: false
+    default: ''
+
+  mongodb-username:
+    description: 'MongoDB root username (default: none)'
+    required: false
+    default: ''
+
+  mongodb-password:
+    description: 'MongoDB root password (default: none)'
+    required: false
+    default: ''
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -28,3 +43,6 @@ runs:
     - ${{ inputs.mongodb-version }}
     - ${{ inputs.mongodb-replica-set }}
     - ${{ inputs.mongodb-port }}
+    - ${{ inputs.mongodb-db }}
+    - ${{ inputs.mongodb-username }}
+    - ${{ inputs.mongodb-password }}

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -4,6 +4,9 @@
 MONGODB_VERSION=$1
 MONGODB_REPLICA_SET=$2
 MONGODB_PORT=$3
+MONGODB_DB=$4
+MONGODB_USERNAME=$5
+MONGODB_PASSWORD=$6
 
 
 if [ -z "$MONGODB_VERSION" ]; then
@@ -19,9 +22,11 @@ if [ -z "$MONGODB_REPLICA_SET" ]; then
   echo "::group::Starting single-node instance, no replica set"
   echo "  - port [$MONGODB_PORT]"
   echo "  - version [$MONGODB_VERSION]"
+  echo "  - database [$MONGODB_DB]"
+  echo "  - credentials [$MONGODB_USERNAME:$MONGODB_PASSWORD]"
   echo ""
 
-  docker run --name mongodb --publish $MONGODB_PORT:27017 --detach mongo:$MONGODB_VERSION
+  docker run --name mongodb --publish $MONGODB_PORT:27017 -e MONGO_INITDB_DATABASE=$MONGODB_DB -e MONGO_INITDB_ROOT_USERNAME=$MONGODB_USERNAME -e MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD --detach mongo:$MONGODB_VERSION
   echo "::endgroup::"
 
   return
@@ -34,7 +39,7 @@ echo "  - version [$MONGODB_VERSION]"
 echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
 
-docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION mongod --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
+docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
 echo "::endgroup::"
 
 

--- a/test/single-instance.js
+++ b/test/single-instance.js
@@ -11,7 +11,11 @@ describe('MongoDB Single Instance ->', () => {
     await expect(
       Mongoose.connect('mongodb://localhost', {
         useNewUrlParser: true,
-        useUnifiedTopology: true
+        useUnifiedTopology: true,
+        user: process.env.MONGODB_USERNAME,
+        pass: process.env.MONGODB_PASSWORD,
+        dbName: process.env.MONGODB_DB,
+        authSource: 'admin'
       })
     ).to.not.reject()
   })


### PR DESCRIPTION
Hi folks!

Started using this action and found the need for quick initial root user creation, also saw an open issue that didn't appear to have been solved so I thought I'd sort out a solution.

This PR:
- Adds parsing of the `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` env vars (as `mongodb-username` and `mongodb-password` inputs respectively), which automatically enable `--auth` as per the official docker container logs;
- Adds `mongodb-db` which will create a DB;
- Modifies the single instance test to use these auth parameters;
- Updates the README to document the new options (including a note as to how this apparently doesn't work in conjunction with `--replSet`)

Hopefully fixes #12 

_Also, sidenote: I've tested the vars as blank strings and the container just ignores them, I almost added them to the test matrices but it wound up making like 86 jobs per test because of al the node and JS versions being tested :shrug: _