### PR TITLE
FIX: raise error on missing docker image

### DIFF
--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -51,6 +51,10 @@ echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
 
 docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
+if ! docker inspect -f "{{.State.Running}}" "mongodb"; then
+    echo "Docker didn't start."
+    exit 2
+fi
 echo "::endgroup::"
 
 

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -51,8 +51,8 @@ echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
 
 docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
-if ! docker inspect -f "{{.State.Running}}" "mongodb"; then
-    echo "Docker didn't start."
+if [ $? -ne 0 ]; then
+    echo "Error starting docker"
     exit 2
 fi
 echo "::endgroup::"


### PR DESCRIPTION
I ran manual test to check it raises an error with.

```shell
start-mongodb.sh 7.0
::group::Selecting correct MongoDB client
  - Using [mongosh --quiet]

::endgroup::
::group::Starting single-node instance, no replica set
  - port []
  - version [7.0]
  - database []
  - credentials [:]

Unable to find image 'mongo:7.0' locally
docker: Error response from daemon: manifest for mongo:7.0 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
::endgroup::
****/mongodb-github-action/start-mongodb.sh: line 43: return: can only `return' from a function or sourced script
::group::Starting MongoDB as single-node replica set
  - port []
  - version [7.0]
  - replica set []

docker: No port specified: :<empty>.
See 'docker run --help'.

Error: No such object: mongodb
Docker didn't start.
```

I also verified it works with an existing image

```shell
start-mongodb.sh 6.0
::group::Selecting correct MongoDB client
  - Using [mongosh --quiet]

::endgroup::
::group::Starting single-node instance, no replica set
  - port []
  - version [6.0]
  - database []
  - credentials [:]

Unable to find image 'mongo:6.0' locally
6.0: Pulling from library/mongo
3b65ec22a9e9: Downloading [=========>                                         ]  5.573MB/28.57MB
016bc871e2b3: Download complete 
9ddd649edd82: Download complete 
39bf776c01e4: Downloading [===========================>                       ]  3.582MB/6.506MB
f7f0405a2fe3: Download complete 
89785d0d9c65: Waiting 
fd40d84c80b0: Waiting 
d50d65ac4752: Waiting 
255e24cbd370: Pulling fs layer 
^C
```
fixes #36 