### PR TITLE
Allow user-defined container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,48 @@ jobs:
         CI: true
 ```
 
+### With Custom Container Name
+The container name of the created MongoDB instance can be configured using the `container-name` input
+
+The following example will parameterize the MongoDB container name based on the `node-version` and `mongodb-version` being used from the matrix:
+
+```yaml
+name: Run with Custom Container Names
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+        mongodb-version: ['4.2', '4.4', '5.0', '6.0']
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.10.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+        container-name: mongodb-${{ matrix.node-version }}-${{ matrix.mongodb-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test
+      env:
+        CI: true
+```
+
 **Caveat:** due to [this issue](https://github.com/docker-library/mongo/issues/211), you **cannot enable user creation AND replica sets** initially. Therefore, if you use this action to setup a replica set, please create your users through a separate script.
 
 

--- a/action-types.yml
+++ b/action-types.yml
@@ -12,3 +12,5 @@ inputs:
     type: string
   mongodb-password:
     type: string
+  container-name:
+    type: string

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,11 @@ inputs:
     required: false
     default: ''
 
+  container-name:
+    description: 'MongoDB container name (default: "mongodb")'
+    required: false
+    default: "mongodb"
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -46,3 +51,4 @@ runs:
     - ${{ inputs.mongodb-db }}
     - ${{ inputs.mongodb-username }}
     - ${{ inputs.mongodb-password }}
+    - ${{ inputs.container-name }}

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ inputs:
   container-name:
     description: 'MongoDB container name (default: "mongodb")'
     required: false
-    default: "mongodb"
+    default: 'mongodb'
 
 runs:
   using: 'docker'

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -57,14 +57,19 @@ wait_for_mongodb () {
     sleep 1
     TIMER=$((TIMER + 1))
 
-    if [[ $TIMER -eq 20 ]]; then
-      echo "MongoDB did not initialize within 20 seconds. Exiting."
+    if [[ $TIMER -eq 40 ]]; then
+      echo "MongoDB did not initialize within 40 seconds. Exiting."
       exit 2
     fi
   done
   echo "::endgroup::"
 }
 
+# check if the container already exists and remove it
+if [ "$(docker ps -q -f name=$MONGODB_CONTAINER_NAME)" ]; then
+  echo "Removing existing container [$MONGODB_CONTAINER_NAME]"
+  docker rm -f $MONGODB_CONTAINER_NAME
+fi
 
 if [ -z "$MONGODB_REPLICA_SET" ]; then
   echo "::group::Starting single-node instance, no replica set"
@@ -94,6 +99,7 @@ echo "  - port [$MONGODB_PORT]"
 echo "  - version [$MONGODB_VERSION]"
 echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
+
 
 docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET
 

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -51,7 +51,7 @@ wait_for_mongodb () {
   fi
 
   # until ${WAIT_FOR_MONGODB_COMMAND}
-  until docker exec --tty mongodb $MONGODB_CLIENT --port $MONGODB_PORT $MONGODB_ARGS --eval "db.serverStatus()"
+  until docker exec --tty $MONGODB_CONTAINER_NAME $MONGODB_CLIENT --port $MONGODB_PORT $MONGODB_ARGS --eval "db.serverStatus()"
   do
     echo "."
     sleep 1

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -7,6 +7,7 @@ MONGODB_PORT=$3
 MONGODB_DB=$4
 MONGODB_USERNAME=$5
 MONGODB_PASSWORD=$6
+MONGODB_CONTAINER_NAME=$6
 
 # `mongosh` is used starting from MongoDB 5.x
 MONGODB_CLIENT="mongosh --quiet"
@@ -73,7 +74,7 @@ if [ -z "$MONGODB_REPLICA_SET" ]; then
   echo "  - credentials [$MONGODB_USERNAME:$MONGODB_PASSWORD]"
   echo ""
 
-  docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT -e MONGO_INITDB_DATABASE=$MONGODB_DB -e MONGO_INITDB_ROOT_USERNAME=$MONGODB_USERNAME -e MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD --detach mongo:$MONGODB_VERSION --port $MONGODB_PORT
+  docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT -e MONGO_INITDB_DATABASE=$MONGODB_DB -e MONGO_INITDB_ROOT_USERNAME=$MONGODB_USERNAME -e MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD --detach mongo:$MONGODB_VERSION --port $MONGODB_PORT
 
   if [ $? -ne 0 ]; then
       echo "Error starting MongoDB Docker container"
@@ -93,7 +94,7 @@ echo "  - version [$MONGODB_VERSION]"
 echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
 
-docker run --name mongodb --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
+docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
 
 if [ $? -ne 0 ]; then
     echo "Error starting MongoDB Docker container"
@@ -105,7 +106,7 @@ wait_for_mongodb
 
 echo "::group::Initiating replica set [$MONGODB_REPLICA_SET]"
 
-docker exec --tty mongodb $MONGODB_CLIENT --port $MONGODB_PORT --eval "
+docker exec --tty $MONGODB_CONTAINER_NAME $MONGODB_CLIENT --port $MONGODB_PORT --eval "
   rs.initiate({
     \"_id\": \"$MONGODB_REPLICA_SET\",
     \"members\": [ {
@@ -120,5 +121,5 @@ echo "::endgroup::"
 
 
 echo "::group::Checking replica set status [$MONGODB_REPLICA_SET]"
-docker exec --tty mongodb $MONGODB_CLIENT --port $MONGODB_PORT --eval "rs.status()"
+docker exec --tty $MONGODB_CONTAINER_NAME $MONGODB_CLIENT --port $MONGODB_PORT --eval "rs.status()"
 echo "::endgroup::"

--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -7,7 +7,7 @@ MONGODB_PORT=$3
 MONGODB_DB=$4
 MONGODB_USERNAME=$5
 MONGODB_PASSWORD=$6
-MONGODB_CONTAINER_NAME=$6
+MONGODB_CONTAINER_NAME=$7
 
 # `mongosh` is used starting from MongoDB 5.x
 MONGODB_CLIENT="mongosh --quiet"
@@ -72,6 +72,7 @@ if [ -z "$MONGODB_REPLICA_SET" ]; then
   echo "  - version [$MONGODB_VERSION]"
   echo "  - database [$MONGODB_DB]"
   echo "  - credentials [$MONGODB_USERNAME:$MONGODB_PASSWORD]"
+  echo "  - container-name [$MONGODB_CONTAINER_NAME]"
   echo ""
 
   docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT -e MONGO_INITDB_DATABASE=$MONGODB_DB -e MONGO_INITDB_ROOT_USERNAME=$MONGODB_USERNAME -e MONGO_INITDB_ROOT_PASSWORD=$MONGODB_PASSWORD --detach mongo:$MONGODB_VERSION --port $MONGODB_PORT
@@ -94,7 +95,7 @@ echo "  - version [$MONGODB_VERSION]"
 echo "  - replica set [$MONGODB_REPLICA_SET]"
 echo ""
 
-docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET --port $MONGODB_PORT
+docker run --name $MONGODB_CONTAINER_NAME --publish $MONGODB_PORT:$MONGODB_PORT --detach mongo:$MONGODB_VERSION --replSet $MONGODB_REPLICA_SET
 
 if [ $? -ne 0 ]; then
     echo "Error starting MongoDB Docker container"


### PR DESCRIPTION
I ran into #24 when using this action inside a matrix. The workflow was attempting to start multiple mongodb containers, causing all but one to error out.

My solution to this was to allow the container name to be input as a configuration option, and using the matrix to differentiate the container names and ports.

Example:

    strategy:
      fail-fast: false
      matrix:
        python-version: ["3.10", "3.11", "3.12"]

    steps:
      - name: Calculate port
        id: calc
        run: |
          PYTHON_VER_INT=$(echo "${{ matrix.python-version }}" | tr -d '.')
          PORT=$((27000 + PYTHON_VER_INT))
          echo "port=$PORT" >> $GITHUB_OUTPUT

      - name: Setup MongoDB service
        uses: alexdlukens/mongodb-github-action@fa13afeb0a920f19491292b6819a6129c09fb42b
        with:
          mongodb-version: 4.4
          mongodb-port: ${{ steps.calc.outputs.port }}
          container-name: mongodb-${{ matrix.python-version }}

Edit:

Would like to note that this issue occurred when running the workflow locally via [act](https://github.com/nektos/act)
