### PR TITLE
fix: Update Dockerfile to use latest docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker:stable
+FROM docker:latest
 COPY start-mongodb.sh /start-mongodb.sh
 RUN chmod +x /start-mongodb.sh
 ENTRYPOINT ["/start-mongodb.sh"]
+


### PR DESCRIPTION
The stable tag is from 2019. And the docker client version isn't supported anymore, which leads to this error:

```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```