### PR TITLE
fix: [ad-hoc] Move away from stale docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM docker:cli
 COPY start-mongodb.sh /start-mongodb.sh
 RUN chmod +x /start-mongodb.sh
 ENTRYPOINT ["/start-mongodb.sh"]


### PR DESCRIPTION
### Description
- docker:stable has been deprecated since June 2020 and is frozen at Docker 20.10 (API 1.40) — exactly the version in the error
- docker:cli is the actively maintained tag for Docker CLI-only images, currently at Docker 29.x (well above API 1.44)