### PR TITLE
fix: catch and exit with error when rs initialization fails

### DIFF
--- a/start-mongodb.sh
+++ b/start-mongodb.sh
@@ -205,10 +205,21 @@ docker exec --tty $MONGODB_CONTAINER_NAME $MONGODB_CLIENT --port $MONGODB_PORT $
   })
 "
 
+if [ $? -ne 0 ]; then
+  echo "Error initiating replica set [$MONGODB_REPLICA_SET]"
+  exit 2
+fi
+
 echo "Success! Initiated replica set [$MONGODB_REPLICA_SET]"
 echo "::endgroup::"
 
 
 echo "::group::Checking replica set status [$MONGODB_REPLICA_SET]"
 docker exec --tty $MONGODB_CONTAINER_NAME $MONGODB_CLIENT --port $MONGODB_PORT $MONGODB_ARGS --eval "rs.status()"
+
+if [ $? -ne 0 ]; then
+  echo "Error checking replica set status [$MONGODB_REPLICA_SET]"
+  exit 2
+fi
+
 echo "::endgroup::"


### PR DESCRIPTION
There are cases that mongo may fail to start or fail to initialize, however the error was not resulting in Action error so that Users get feedback e.g.
```
Initiating replica set [rs0]
  ]0;mongosh mongodb://<credentials>@127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017
  Success! Initiated replica set [rs0]
Checking replica set status [rs0]
  ]0;mongosh mongodb://<credentials>@127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017
```

I've stumbled on that probably because of https://github.com/docker-library/mongo/discussions/748